### PR TITLE
chore: add Dependabot config for uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を新規追加し、uv エコシステム向けの Dependabot を有効化
- 週次（毎週月曜 09:00 JST）で Python 依存の更新をチェック
- 開発依存（dev group）は 1 PR にまとめてノイズを削減
- コミットメッセージは `chore(scope): ...` に統一、`dependencies` ラベルを付与

## Notes

- リポジトリ上で以前から `dependabot/uv/...` ブランチのマージ実績があり、GitHub 側で有効化されていた形跡はあるが、リポジトリ内には設定ファイルが無かったため明示的にコミット
- ワークフロー未整備のため `github-actions` エコシステムは含めず（追加はワークフロー導入時に検討）

## Test plan

- [ ] マージ後、Dependabot の Insights タブで `.github/dependabot.yml` が認識されているか確認
- [ ] 次回スケジュール実行時に PR が作成されるか確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4oA6WLM6qaSZfQSEEakzx)_